### PR TITLE
Fixed use of option "expose files".

### DIFF
--- a/metadata/Mets.php
+++ b/metadata/Mets.php
@@ -77,7 +77,7 @@ class OaiPmhRepository_Metadata_Mets extends OaiPmhRepository_Metadata_Abstract
             }
         }
         $fileIds = array();
-        if (metadata($this->item,'has files')) {          
+        if (get_option('oaipmh_repository_expose_files') && metadata($this->item, 'has files')) {
             $fileSection = $this->appendNewElement($mets, 'fileSec');
             $fileGroup = $this->appendNewElement($fileSection, 'fileGrp');
             $fileGroup->setAttribute('USE', 'ORIGINAL');


### PR DESCRIPTION
Hi,

For METS and omeka-xml, the option `oaipmh_repository_expose_files` is not checked and files are always added. This is fixed, except for omeka-xml format. Other changes are just for similarity. See https://github.com/zerocrates/OaiPmhRepository/issues/8#issuecomment-59038748.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
