### PR TITLE
Fix PHP 8.1 non-nullable deprecation warning.

### DIFF
--- a/libraries/OaiPmhRepository/Date.php
+++ b/libraries/OaiPmhRepository/Date.php
@@ -102,9 +102,9 @@ class OaiPmhRepository_Date {
      */
     public static function getGranularity($dateTime)
     {
-        if (preg_match(self::OAI_DATE_PCRE, $dateTime)) {
+        if (preg_match(self::OAI_DATE_PCRE, (string) $dateTime)) {
             return self::OAI_GRANULARITY_DATE;
-        } else if (preg_match(self::OAI_DATETIME_PCRE, $dateTime)) {
+        } else if (preg_match(self::OAI_DATETIME_PCRE, (string) $dateTime)) {
             return self::OAI_GRANULARITY_DATETIME;
         } else {
             return false;


### PR DESCRIPTION
This fixes a deprecation warning found when testing with PHP 8.1 or greater, due to null being passed to a non-nullable parameter.